### PR TITLE
Add custom headers to checks

### DIFF
--- a/lib/check.rb
+++ b/lib/check.rb
@@ -5,6 +5,7 @@ class Check
 
   attr_accessor :name
   attr_accessor :url
+  attr_accessor :headers
   attr_accessor :frequency
   attr_accessor :method
   attr_accessor :data
@@ -17,6 +18,7 @@ class Check
   def initialize(options)
     self.name = options[:name]
     self.url = options[:url]
+    self.headers = options[:headers]
     self.frequency = options[:frequency]
     self.method = (options[:method] || "GET").upcase
     self.data = options[:data]
@@ -36,6 +38,7 @@ class Check
   def to_hash
     { :name => self.name,
       :url => self.url,
+      :headers => self.headers,
       :frequency => self.frequency,
       :method => self.method,
       :data => self.data,

--- a/lib/eventmachine_check_runner.rb
+++ b/lib/eventmachine_check_runner.rb
@@ -11,7 +11,7 @@ class EventmachineCheckRunner
       start_time = Time.now
       em = EventMachine::HttpRequest.new(check.url, em_http_options(config))
 
-      headers = {}
+      headers = check.headers || {}
       if check.http_username && check.http_password
         headers[:authorization] = [check.http_username, check.http_password]
       end

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -5,6 +5,7 @@ describe Check do
     Check.new(
       :name => 'foo',
       :url => 'http://keen.io',
+      :headers => {:'Accept' => 'application/json'},
       :frequency => 60,
       :save_body => true,
       :http_username => 'borg',
@@ -46,6 +47,7 @@ describe Check do
       expect(check.to_hash).to eq({
         :name => "foo",
         :url => "http://keen.io",
+        :headers => {:'Accept' => 'application/json'},
         :save_body => true,
         :frequency => 60,
         :method => "GET",


### PR DESCRIPTION
I needed to have the possibility to add custom headers to the requests being made. 
With this pull requests `checks.json` can now have a hash containing headers:

``` json
{
  "checks": [
    {
      "name": "check with custom headers",
      "url": "http://example.com",
      "frequency": 5,
      "headers": {"HeaderFoo": "foo", "HeaderBar": "bar"},
      "method": "GET",
      "data": null
    }
  ]
}
```

Additionally the Header field could be added as a prompt on the rake task: `bundle exec rake checks:add`
