### PR TITLE
Fix README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you don't have the `bundle` command, first `gem install bundler`.
 **Step 3:** Set up database tables
 
 ```
+$ mkdir -p db/migrate
 $ thor pingpong:setup
 ```
 


### PR DESCRIPTION
On Step 3 of the installation instructions, before running:

```sh
$ thor pingpong:setup
```

The user needs to run:

```sh
$ mkdir -p db/migrate
```

So the database setup will work.