### PR TITLE
Slack notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,5 @@ group :development, :test do
   gem 'rspec'
   gem 'webmock'
   gem 'factory_girl'
+  gem 'pry'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem 'keen'
 
 gem 'pushpop'
 gem 'pushpop-keen'
-gem 'pushpop-sendgrid'
+gem 'pushpop-sendgrid', :git => 'git@github.com:pushpop-project/pushpop-sendgrid.git'
+gem 'pushpop-slack'
 
 gem 'pg', '0.18.1'
 gem 'rack-flash3'

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'keen'
 
 gem 'pushpop'
 gem 'pushpop-keen'
-gem 'pushpop-sendgrid', :git => 'git@github.com:pushpop-project/pushpop-sendgrid.git'
+gem 'pushpop-sendgrid'
 gem 'pushpop-slack'
 
 gem 'pg', '0.18.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     pushpop-keen (0.1.1)
       keen
       pushpop
-    pushpop-slack (0.2.2)
+    pushpop-slack (0.2.3)
       pushpop
       slack-notifier
     rack (1.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git@github.com:pushpop-project/pushpop-sendgrid.git
-  revision: 7fc7742907683f43756e73c8bec21229021c0d7a
-  specs:
-    pushpop-sendgrid (0.1.3)
-      mail
-      pushpop
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -73,12 +65,20 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry (0.10.1-x64-mingw32)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      win32console (~> 1.3)
     pushpop (0.2)
       clockwork
       dotenv
       thor
     pushpop-keen (0.1.1)
       keen
+      pushpop
+    pushpop-sendgrid (0.1.3)
+      mail
       pushpop
     pushpop-slack (0.2.3)
       pushpop
@@ -126,6 +126,7 @@ GEM
     webmock (1.17.1)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
+    win32console (1.3.2)
 
 PLATFORMS
   ruby
@@ -146,7 +147,7 @@ DEPENDENCIES
   pry
   pushpop
   pushpop-keen
-  pushpop-sendgrid!
+  pushpop-sendgrid
   pushpop-slack
   rack-flash3
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     pushpop-keen (0.1.1)
       keen
       pushpop
-    pushpop-slack (0.2.1)
+    pushpop-slack (0.2.2)
       pushpop
       slack-notifier
     rack (1.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     clockwork (1.2.0)
       activesupport
       tzinfo
+    coderay (1.1.0)
     cookiejar (0.3.0)
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
@@ -61,12 +62,17 @@ GEM
       multi_json (~> 1.3)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.5)
     minitest (5.6.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     pg (0.18.1)
     pg (0.18.1-x64-mingw32)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     pushpop (0.2)
       clockwork
       dotenv
@@ -111,6 +117,7 @@ GEM
     sinatra-reloader (1.0)
       sinatra-contrib
     slack-notifier (1.2.0)
+    slop (3.6.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -136,6 +143,7 @@ DEPENDENCIES
   keen
   multi_json
   pg (= 0.18.1)
+  pry
   pushpop
   pushpop-keen
   pushpop-sendgrid!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git@github.com:pushpop-project/pushpop-sendgrid.git
+  revision: 7fc7742907683f43756e73c8bec21229021c0d7a
+  specs:
+    pushpop-sendgrid (0.1.3)
+      mail
+      pushpop
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -18,14 +26,14 @@ GEM
     arel (6.0.0)
     backports (3.4.1)
     builder (3.2.2)
-    clockwork (0.7.5)
+    clockwork (1.2.0)
       activesupport
       tzinfo
     cookiejar (0.3.0)
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     diff-lcs (1.2.5)
-    dotenv (0.9.0)
+    dotenv (2.0.1)
     em-http-request (1.1.2)
       addressable (>= 2.3.4)
       cookiejar
@@ -51,22 +59,24 @@ GEM
     keen (0.8.6)
       addressable (~> 2.3.5)
       multi_json (~> 1.3)
-    mail (2.6.1)
+    mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.3)
+    mime-types (2.5)
     minitest (5.6.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     pg (0.18.1)
     pg (0.18.1-x64-mingw32)
-    pushpop (0.1.1)
+    pushpop (0.2)
       clockwork
+      dotenv
+      thor
     pushpop-keen (0.1.1)
       keen
       pushpop
-    pushpop-sendgrid (0.1.2)
-      mail
+    pushpop-slack (0.2.1)
       pushpop
+      slack-notifier
     rack (1.5.2)
     rack-flash3 (1.0.5)
       rack
@@ -100,7 +110,8 @@ GEM
       tilt (~> 1.3)
     sinatra-reloader (1.0)
       sinatra-contrib
-    thor (0.18.1)
+    slack-notifier (1.2.0)
+    thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
     tzinfo (1.2.2)
@@ -127,7 +138,8 @@ DEPENDENCIES
   pg (= 0.18.1)
   pushpop
   pushpop-keen
-  pushpop-sendgrid
+  pushpop-sendgrid!
+  pushpop-slack
   rack-flash3
   rake
   rspec

--- a/README.md
+++ b/README.md
@@ -87,7 +87,23 @@ SENDGRID_PASSWORD=12345
 
 ***Slack Setup***
 
-Coming soon!
+To get notifications in Slack, you'll have to provide us with your Incoming Webhook URL. You can create an Incoming Webhook [here](https://slack.com/services/new/incoming-webhook)
+
+Once you've got the Webhook URL, drop it in your `.env` file:
+
+```
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXXXXXXXXXXXXXX/YYYYYYYYYYY
+```
+
+There are also some optional configurations you can put in for Slack notifications:
+
+```
+SLACK_CHANNEL='#alerts' # The channel to send notifcations to
+SLACK_USERNAME='Robot' # The username the notification will come from - defaults to Pingpong
+SLACK_ICON=':rotating_light' # The icon of the user "sending" the notification. Can be a URL or an Emoji
+WARN_COLOR='#CCCCCC' # Hex color value used for the warning messages - defaults to #E2E541
+BAD_COLOR='#000000' # Hex color value used for the failure messages - defaults to #F25656
+```
 
 ***Run the Server***
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ SENDGRID_PASSWORD=12345
 
 ***Slack Setup***
 
-To get notifications in Slack, you'll have to provide us with your Incoming Webhook URL. You can create an Incoming Webhook [here](https://slack.com/services/new/incoming-webhook)
+To get notifications in Slack, you'll have to provide us with your Incoming Webhook URL. You can create an Incoming Webhook [here](https://slack.com/services/new/incoming-webhook).
 
 Once you've got the Webhook URL, drop it in your `.env` file:
 

--- a/app.json
+++ b/app.json
@@ -22,6 +22,10 @@
       "description": "The from email address for alert emails.",
       "value": ""
     },
+    "SLACK_WEBHOOK_URL": {
+      "description": "Optional: Webhook URL for Slack notifications",
+      "required": false
+    },
     "KEEN_COLLECTION": {
       "description": "Name of the collection to store the checks in.",
       "value": "checks",

--- a/app.rb
+++ b/app.rb
@@ -105,6 +105,8 @@ def update_check(check, params)
   check.http_username = params[:http_username]
   check.http_password = params[:http_password]
   check.email_warn = params[:email_warn] == 'on'
+  check.slack_warn = params[:slack_warn] == 'on'
+  check.slack_bad = params[:slack_bad] == 'on'
 
   check
 end

--- a/config.yml
+++ b/config.yml
@@ -19,6 +19,13 @@ defaults: &defaults
     master_key: <%= ENV['KEEN_MASTER_KEY'] %>
     collection: <%= ENV['KEEN_COLLECTION'] || 'checks' %>
 
+  slack: 
+    channel: <%= ENV['SLACK_CHANNEL'] %>
+    username: <%= ENV['SLACK_USERNAME'] || 'Pingpong' %>
+    icon: <%= ENV['SLACK_ICON'] %>
+    warn_color: '<%= ENV['WARN_COLOR'] || '#E2E541' %>'
+    bad_color: '<%= ENV['BAD_COLOR'] || '#F25656' %>'
+
   # by default a web worker will run checks
   skip_checks: <%= ENV['SKIP_CHECKS'] %>
 

--- a/db/migrate/20150427160230_create_checks_and_incidents.rb
+++ b/db/migrate/20150427160230_create_checks_and_incidents.rb
@@ -13,7 +13,7 @@ class CreateChecksAndIncidents < ActiveRecord::Migration
 
       t.text :custom_properties
       t.text :incident_checking
-      t.text :configurations, :default => '{"email_warn":false, "email_bad":true}'
+      t.text :configurations, :default => '{"email_warn":false, "email_bad":true, "slack_warn":false, "slack_bad":true}'
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20150427160230) do
     t.string   "http_password"
     t.text     "custom_properties"
     t.text     "incident_checking"
-    t.text     "configurations",    default: "{\"email_warn\":false, \"email_bad\":true}"
+    t.text     "configurations",    default: "{\"email_warn\":false, \"email_bad\":true, \"slack_bad\":true, \"slack_warn\":false}"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/jobs/run_checks_job.rb
+++ b/jobs/run_checks_job.rb
@@ -90,7 +90,7 @@ job 'run_checks' do
 
         slack_attachment = {
           fallback: "Attachment couldn't be displayed - your client only supports plaintext",
-          color: check.is_bad? ? config.properties[:slack][:warn_color] : config.properties[:slack][:warn_color],
+          color: check.is_bad? ? config.properties[:slack][:bad_color] : config.properties[:slack][:warn_color],
           title: check.name,
           title_link: check.url,
           mrkdwn_in: ['fields'],

--- a/jobs/run_checks_job.rb
+++ b/jobs/run_checks_job.rb
@@ -76,20 +76,21 @@ job 'run_checks' do
           send_email config.properties[:to_email_address], config.properties[:from_email_address], subject, body, nil
         end
       end
+      true
+    else
+      false
     end
-
-    true
   end
 
-  slack do |response, step_responses|
-    step_responses['run checks'].each do |check|
+  slack 'send slack message' do |response, step_responses|
+    step_responses['run checks'].each_with_index do |check, index|
       if (check.is_bad? && check.slack_bad) || (check.is_warn? && check.slack_warn)
         config.logger.info("sending slack message for #{check.name}")
         incident = Incident.most_recent_for_check(check, 1).first
 
         slack_attachment = {
           fallback: "Attachment couldn't be displayed - your client only supports plaintext",
-          color: check.is_bad? ? config.properties[:slack][:warn_color] : config.properties[:slack][:bad_color],
+          color: check.is_bad? ? config.properties[:slack][:warn_color] : config.properties[:slack][:warn_color],
           title: check.name,
           title_link: check.url,
           mrkdwn_in: ['fields'],
@@ -117,7 +118,12 @@ job 'run_checks' do
         icon config.properties[:slack][:icon] if config.properties[:slack][:icon]
         message incident.notification_subject
         attachment slack_attachment
+
+        send_message
       end 
     end
+      # pushpop-slack calls send_message internally at the end of the step
+      # so if we set the message to nil it will just abort rather than duplicate the last check message
+      self._message = nil
   end
 end

--- a/jobs/run_checks_job.rb
+++ b/jobs/run_checks_job.rb
@@ -16,7 +16,7 @@ require File.dirname(__FILE__) + "/../lib/check.rb"
 
 KEEN_COLLECTION = ENV['KEEN_COLLECTION'] || 'checks'
 
-job do
+job 'run_checks' do
 
   every 1.minute
 
@@ -67,7 +67,7 @@ job do
   sendgrid 'send emails' do |response, step_responses|
     if !response.empty?
       response.each do |check|
-        if (check.is_bad?) || (check.is_warn? && check.email_warn?)
+        if (check.is_bad?) || (check.is_warn? && check.email_warn)
           config.logger.info("sending email for #{check.name}")
           incident = Incident.most_recent_for_check(check, 1).first
           subject = incident.email_subject

--- a/jobs/run_checks_job.rb
+++ b/jobs/run_checks_job.rb
@@ -1,9 +1,9 @@
 require 'pushpop'
 require 'pushpop-keen'
 require 'pushpop-sendgrid'
-
 require 'dotenv'
 Dotenv.load
+require 'pushpop-slack'
 
 require 'sinatra'
 require 'sinatra/activerecord'
@@ -70,12 +70,54 @@ job 'run_checks' do
         if (check.is_bad?) || (check.is_warn? && check.email_warn)
           config.logger.info("sending email for #{check.name}")
           incident = Incident.most_recent_for_check(check, 1).first
-          subject = incident.email_subject
-          body = incident.email_body
+          subject = incident.notification_subject
+          body = incident.notification_body
 
           send_email config.properties[:to_email_address], config.properties[:from_email_address], subject, body, nil
         end
       end
+    end
+
+    true
+  end
+
+  slack do |response, step_responses|
+    step_responses['run checks'].each do |check|
+      if (check.is_bad? && check.slack_bad) || (check.is_warn? && check.slack_warn)
+        config.logger.info("sending slack message for #{check.name}")
+        incident = Incident.most_recent_for_check(check, 1).first
+
+        slack_attachment = {
+          fallback: "Attachment couldn't be displayed - your client only supports plaintext",
+          color: check.is_bad? ? config.properties[:slack][:warn_color] : config.properties[:slack][:bad_color],
+          title: check.name,
+          title_link: check.url,
+          mrkdwn_in: ['fields'],
+          fields: [
+            {
+              title: 'URL',
+              value: check.url,
+              short: true
+            },
+            {
+              title: 'Severity',
+              value: check.is_bad? ? 'Failure' : 'Warning',
+              short: true
+            },
+            {
+              title: 'Check Response',
+              value: "```#{JSON.pretty_generate(incident.check_response)}```"
+            }
+          ]
+        } 
+
+
+        channel config.properties[:slack][:channel] if config.properties[:slack][:channel]
+        username config.properties[:slack][:username]
+        icon config.properties[:slack][:icon] if config.properties[:slack][:icon]
+        message incident.notification_subject
+        attachment slack_attachment
+      end 
     end
   end
 end

--- a/lib/check.rb
+++ b/lib/check.rb
@@ -7,7 +7,7 @@ class Check < ActiveRecord::Base
   serialize :headers, JSON
 
   store :incident_checking, accessors: [:response_times, :response_codes], coder: JSON
-  store :configurations, accessors: [:email_warn, :email_bad, :warn_thresh, :bad_thresh], coder: JSON
+  store :configurations, accessors: [:email_warn, :email_bad, :slack_bad, :slack_warn, :warn_thresh, :bad_thresh], coder: JSON
 
   validates :name, presence: true
   validates :url, presence: true
@@ -255,6 +255,8 @@ class Check < ActiveRecord::Base
   def initialize_defaults
     self.email_warn = false
     self.email_bad = true
+    self.slack_bad = true
+    self.slack_warn = false
     self.warn_thresh = MEAN_WARN_THRESHOLD
     self.bad_thresh = MEAN_BAD_THRESHOLD
   end

--- a/lib/incident.rb
+++ b/lib/incident.rb
@@ -55,7 +55,7 @@ class Incident < ActiveRecord::Base
     is_ok? ? "" : is_warn? ? " warning" : " error"
   end
 
-  def email_subject
+  def notification_subject(formatting = false)
     subject = ""
 
     if is_warn?
@@ -64,10 +64,14 @@ class Incident < ActiveRecord::Base
       subject = "Failure"
     end
 
+    if formatting
+      subject = "**#{subject}**"
+    end
+
     subject + " for check '#{check.name}'"
   end
 
-  def email_body
+  def notification_body
     message = "Incident report for check '#{check.name}':<br><br>" +
       info + "<br><br>" +
       "Check Response: <br><br>" +

--- a/pingpong.thor
+++ b/pingpong.thor
@@ -39,7 +39,7 @@ class CreateChecksAndIncidents < ActiveRecord::Migration
 
       t.text :custom_properties
       t.text :incident_checking
-      t.text :configurations, :default => '{"email_warn":false, "email_bad":true}'
+      t.text :configurations, :default => '{"email_warn":false, "email_bad":true, "slack_bad":true, "slack_warn":false}'
 
       t.timestamps
     end

--- a/spec/run_checks_job_spec.rb
+++ b/spec/run_checks_job_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe 'Pushpop' do
+  # Find the correct job
+  job = Pushpop.jobs.find { |job| 
+    job.name == 'run_checks' 
+  }
+
+  describe 'job' do
+    it 'has a job named run_checks'do
+      expect(job.class).to equal(Pushpop::Job)
+    end
+
+    it 'runs every 1 minute' do
+      expect(job.period).to eq(1.minute)
+    end
+  end
+
+  describe 'steps' do
+    describe 'get checks to process' do
+      step = job.steps.find { |step|
+        step.name == 'get checks to process' 
+      }
+
+      let(:check) { Check.new(:name => 'WebCheck', :url => 'http://bark.meow', :frequency => 10) }
+
+      it 'should have this step' do
+        expect(step.class).to equal(Pushpop::Step) 
+      end
+
+      it 'should run steps with the correct frequency' do
+        Check.stub(:all).and_return([check])
+
+        # Should run on 10 minute intervals, so noon works`
+        Time.stub(:now).and_return(Time.parse('2015-05-01 12:00:00 -0000'))
+        expect(step.run.length).to equal(1)
+
+        # Let's do 12:05 PM - that's not on a 10 minute interval
+        Time.stub(:now).and_return(Time.parse('2015-05-01 12:05:00 -0000'))
+        expect(step.run.length).to equal(0)
+      end
+    end
+
+    describe 'send emails' do
+      let(:check) { Check.new(:name => 'WebCheck', :url => 'http://bark.meow', :frequency => 10) }
+      let(:incident) { 
+        Incident.new(
+          :incident_type => 3,
+          :info => 'test',
+          :check_response => { :body => 'tester' },
+          :check => check
+        ) 
+      } 
+
+      step = job.steps.find { |step|
+        step.name == 'send emails'
+      }
+
+      it 'should have this step' do
+        expect(step.class).to equal(Pushpop::Sendgrid) 
+      end
+      
+      it 'should send an email for bad checks' do
+        check.stub(:is_bad?).and_return(true)
+        Incident.stub(:most_recent_for_check).and_return([incident])
+
+        step.should_receive(:send_email)
+
+        step.run([check])
+      end
+      
+      it 'should not send an email for warns' do
+        check.stub(:is_bad?).and_return(false)
+        check.stub(:is_warn?).and_return(true)
+        Incident.stub(:most_recent_for_check).and_return([incident])
+
+        step.should_not_receive(:send_email)
+
+        step.run([check])
+      end
+      
+      it 'should send warning emails if email_warn is true' do
+        check.stub(:is_bad?).and_return(false)
+        check.stub(:is_warn?).and_return(true)
+        check.email_warn = true
+        Incident.stub(:most_recent_for_check).and_return([incident])
+
+        step.should_receive(:send_email)
+
+        step.run([check])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'webmock/rspec'
 require 'sinatra/activerecord'
 require 'factory_girl'
+require 'pushpop'
 
 $: << File.join(File.dirname(__FILE__), 'lib')
 
@@ -21,3 +22,12 @@ require File.expand_path('../support/factory_girl.rb', __FILE__)
 # then the factory files
 require File.expand_path('../factories.rb', __FILE__)
 #Dir["../factories/*.rb"].each {|file| require file }
+
+# then load pushpop
+Dir.glob("#{File.dirname(__FILE__)}/../jobs/**/*.rb").each { |file|
+  require file
+}
+Pushpop.schedule
+
+# quiet down AR
+ActiveRecord::Base.logger = nil

--- a/views/_check_form_fields.haml
+++ b/views/_check_form_fields.haml
@@ -38,6 +38,15 @@
       .checkbox
         %label{:title => "Select if you want to be notified when the check is in a warn state.", :data => {:toggle => "tooltip", :placement => "top"}}
           %input{:type => "checkbox", :name => "email_warn", :id => "email_warn", :checked => @check.try(:email_warn) ? @check.email_warn : false} Email about Warnings
+      .checkbox
+        %label
+          %input{:type => "checkbox", :name => "email_warn", :id => "email_warn", :checked => @check.try(:email_warn) ? @check.email_warn : false} Email about Warnings
+      .checkbox
+        %label
+          %input{:type => "checkbox", :name => "slack_bad", :id => "slack_bad", :checked => @check.try(:slack_bad) ? @check.slack_bad : false} Send Slack message about Failures
+      .checkbox
+        %label
+          %input{:type => "checkbox", :name => "slack_warn", :id => "slack_warn", :checked => @check.try(:slack_warn) ? @check.slack_warn : false} Send Slack message about Warnings
     .form-group
       %label{:title => "The value the request duration has to exceed to create a warning incident (value is a multiplies of the mean).",:data => {:toggle => "tooltip", :placement => "top"}} Warn Threshold
       %input{:type => "text", :name => "warn_thresh", :id => "warn_thresh", :class => "form-control", :value => "#{@check.nil? ? Check::MEAN_WARN_THRESHOLD : @check.warn_thresh}"}


### PR DESCRIPTION
@hex337 This adds slack support!

It defaults to sending slack messages for `bad` incidents, but the user can configure it to send `warn` incidents as well.

All the user _has_ to do to get slack messages running is set up the `SLACK_WEBHOOK_URL` environment variable, although they can optionally configure a bunch of other stuff as well (username, icon, colors, etc.)

The default slack message will look like this:
![screen shot 2015-05-08 at 11 36 21 am](https://cloud.githubusercontent.com/assets/657707/7540860/7c06420c-f576-11e4-92dd-2f1be206cffc.png)
