### PR TITLE
Fix Display of Warnings/Bad Checks in Check Display

### DIFF
--- a/public/checks.js
+++ b/public/checks.js
@@ -10,6 +10,7 @@ var Check = function() {
       elem.empty();
       var showColoredIcon = this.showColoring;
 
+      var self = this;
       $.each(this.checks, function(i, check) {
         var iconCss = "";
         var hasBadTime = false;
@@ -20,11 +21,11 @@ var Check = function() {
         var message = "";
         var coloredIndicator = "";
 
-        if (check.request.duration > this.badAmount) {
+        if (check.request.duration > self.badAmount) {
           iconCss = " error";
           hasBadTime = true;
           message = message + "Very slow response time. "
-        } else if (check.request.duration > this.warnAmount) {
+        } else if (check.request.duration > self.warnAmount) {
           iconCss = " warning";
           hasWarnTime = true;
           message = message + "Slow response time. "
@@ -62,7 +63,7 @@ var Check = function() {
             + '</div>'
             + '<div id="collapse' + i +'" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading' + i +'">'
               + '<div class="panel-body">';
-              
+
         for (var key in check) {
           checkHTML = checkHTML + '<div class="row">'
             + '<div class="col-md-12 json-header">'
@@ -103,7 +104,7 @@ var Check = function() {
             + '</div>';
           }
         }
-        
+
         checkHTML = checkHTML + '</div>'
             + '</div>'
           + '</div>';

--- a/views/check.haml
+++ b/views/check.haml
@@ -155,7 +155,7 @@
 .row
   .col-md-8
     .chart-stage
-      #checks-extraction.extraction-container{:data => {:name => @check[:name], timeframe: "this_30_minutes", :latest => 10, :numchecks => @check.response_times.length, :warnamount => @check.mean_response_time() * @check.warn_thresh, :badamaount => @check.mean_response_time() * @check.bad_thresh}}
+      #checks-extraction.extraction-container{:data => {:name => @check[:name], timeframe: "this_30_minutes", :latest => 10, :numchecks => @check.response_times.length, :warnamount => @check.mean_response_time() * @check.warn_thresh, :badamount => @check.mean_response_time() * @check.bad_thresh}}
         .panel-group#accordion{:role => "tablist", :aria => {:multiselectable => "true"}}
   .col-md-4
     .chart-wrapper


### PR DESCRIPTION
All checks in the check detail list displayed as "good" since the comparison to the bad and warning amounts was comparing to "undefined".

Also, the "badamount" data attribute was misspelled so no checks every displayed as "bad".