### PR TITLE
Use HTML5 type="url" for URL field

### DIFF
--- a/views/_check_form_fields.haml
+++ b/views/_check_form_fields.haml
@@ -8,7 +8,7 @@
     .form-group
       %label Url
       .controls
-        %input{:type => "text", :name => "url", :id => "url", :class => "form-control", :placeholder => "ie http://www.google.com/api", :value => "#{@check.url if !@check.nil?}", :required => ""}
+        %input{:type => "url", :name => "url", :id => "url", :class => "form-control", :placeholder => "ie http://www.google.com/api", :value => "#{@check.url if !@check.nil?}", :required => ""}
         %p.help-block
     .form-group
       %label Method


### PR DESCRIPTION
Makes page compatible with iPad, now it doesn't try to correct URLs to "Https://Blah.com", now they are "https://blah.com" like they should be.