### PR TITLE
Make google font HTTPS-site compatible

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -11,7 +11,7 @@
     %script(src="/checks.js")
     %link(href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet")
     %link(href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.8/c3.min.css" rel="stylesheet")
-    %link(href="http://fonts.googleapis.com/css?family=Raleway:400,500" rel="stylesheet" type="text/css")
+    %link(href="//fonts.googleapis.com/css?family=Raleway:400,500" rel="stylesheet" type="text/css")
     %link(href="/style.css" rel="stylesheet")
     :javascript
       !function(a,b){a("Keen","https://d26b395fwzu5fz.cloudfront.net/3.2.3/keen.min.js",b)}(function(a,b,c){var d,e,f;c["_"+a]={},c[a]=function(b){c["_"+a].clients=c["_"+a].clients||{},c["_"+a].clients[b.projectId]=this,this._config=b},c[a].ready=function(b){c["_"+a].ready=c["_"+a].ready||[],c["_"+a].ready.push(b)},d=["addEvent","setGlobalProperties","trackExternalLink","on"];for(var g=0;g<d.length;g++){var h=d[g],i=function(a){return function(){return this["_"+a]=this["_"+a]||[],this["_"+a].push(arguments),this}};c[a].prototype[h]=i(h)}e=document.createElement("script"),e.async=!0,e.src=b,f=document.getElementsByTagName("script")[0],f.parentNode.insertBefore(e,f)},this);


### PR DESCRIPTION
Removed protocol from google fonts CSS link so it can load on HTTPS-enabled websites